### PR TITLE
Use validated (rather than volunteered) OAuth client id when checking grant type

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,7 +20,7 @@ var express = require('express')
     , passport = require('passport')
     ;
 
-var oauthserver = require('node-oauth2-server');
+var oauthserver = require('oauth2-server');
 
 var routes = require('./routes');
 

--- a/models/oauth.js
+++ b/models/oauth.js
@@ -181,7 +181,12 @@ model.extendedGrant = function(grantType, req, callback) {
     var params = req.body;
   }
 
-  this.grantTypeAllowed(params.client_id, params.grant_type, function(err, allowed) {
+  var client_id = req.oauth.client.clientId;
+  if ('client_id' in params && params.client_id !== client_id) {
+    // if this (deprecated) param is provided, it must be valid!
+    return callback(null, false, null);
+  }
+  this.grantTypeAllowed(client_id, params.grant_type, function(err, allowed) {
     db.User
       .find({ where: { apiKey: params.api_key } })
       .success(function(user) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "express": "4.0.0",
-    "node-oauth2-server": "2.1.0",
+    "node-oauth2-server": "git://github.com/thomseddon/node-oauth2-server.git#9c4e9b1a",
     "static-favicon": "1.0.0",
     "morgan": "1.0.0",
     "cookie-parser": "1.0.1",


### PR DESCRIPTION
Fixes #33.